### PR TITLE
compatible with sys/param.h

### DIFF
--- a/include/cos_defines.h
+++ b/include/cos_defines.h
@@ -78,8 +78,8 @@ typedef enum cos_log_level {
 #define SDK_LOG_ERR(fmt, ...)           COS_LOW_LOGPRN(COS_LOG_ERR,  fmt, ##__VA_ARGS__, "")
 #define SDK_LOG_COS(level, fmt, ...)    COS_LOW_LOGPRN(level,  fmt, ##__VA_ARGS__, "")
 
-#define MIN(a, b) ((a) < (b) ? (a) : (b))
-#define MAX(a, b) ((a) > (b) ? (a) : (b))
+#define MIN(a,b) (((a)<(b))?(a):(b))
+#define MAX(a,b) (((a)>(b))?(a):(b))
 
 struct Content {
     std::string m_key; // Object 的 Key


### PR DESCRIPTION
详见sys/param.h:98:0
写法不一致的话，编译时如果同时引入两个头文件，会有warning