### PR TITLE
Fixes #79

### DIFF
--- a/src/cos_api.cpp
+++ b/src/cos_api.cpp
@@ -18,30 +18,10 @@ bool CosAPI::s_poco_init = false;
 int CosAPI::s_cos_obj_num = 0;
 std::mutex g_init_lock;
 
-class GlobalTaskManagerSingletonHolder
+Poco::TaskManager& GetGlobalTaskManager()
 {
-public:
-    GlobalTaskManagerSingletonHolder() { g_async_task_manager = nullptr; }
-    ~GlobalTaskManagerSingletonHolder() { delete g_async_task_manager; }
-
-    Poco::TaskManager& GetGlobalTaskManager()
-    {
-        if (g_async_task_manager == nullptr)
-        {
-            g_async_task_manager = new Poco::TaskManager();
-        }
-        return *g_async_task_manager;
-    }
-
-private:
-    Poco::TaskManager* g_async_task_manager = nullptr;
-};
-
-GlobalTaskManagerSingletonHolder g_async_task_manager_holder;
-
-static Poco::TaskManager& GetGlobalTaskManager()
-{
-    return g_async_task_manager_holder.GetGlobalTaskManager();
+    static Poco::TaskManager task_manager;
+    return task_manager;
 }
 
 CosAPI::CosAPI(CosConfig& config)


### PR DESCRIPTION
Using `Poco::Thread` as a global variable will result in the member function `Poco::FastMutex` being called before it is actually constructed, resulting in a crash or a deadlock when used in a separate module (for example, a DLL), depending on the target platform. 

Since [this is not the intended usage](https://github.com/pocoproject/poco/issues/282#issuecomment-45144394), changing the global `Poco::TaskManager` to lazy-initialized will fix this. It will make sure that the static singleton in Poco initializes before it being used.