### PR TITLE
图片上传时处理兼容覆盖原图，不检查Etag

### DIFF
--- a/include/cos_api.h
+++ b/include/cos_api.h
@@ -773,7 +773,7 @@ class CosAPI {
   /** 图片持久化处理 **/
 
   /*** 上传时处理 ***/
-  CosResult PutImage(const PutImageByFileReq& req, PutImageByFileResp* resp);
+  CosResult PutImage(PutImageByFileReq& req, PutImageByFileResp* resp);
 
   /*** 云上数据处理 ***/
   CosResult CloudImageProcess(const CloudImageProcessReq& req,

--- a/include/request/data_process_req.h
+++ b/include/request/data_process_req.h
@@ -277,6 +277,8 @@ class PicOperation {
   PicOperation() : is_pic_info(true) {}
   virtual ~PicOperation() {}
 
+  std::vector<PicRules> GetRules() const { return rules; }
+
   void AddRule(const PicRules& rule) { rules.push_back(rule); }
 
   void TurnOffPicInfo() { is_pic_info = false; }
@@ -601,19 +603,19 @@ class PutImageByFileReq : public PutObjectByFileReq {
   PutImageByFileReq(const std::string& bucket_name,
                     const std::string& object_name,
                     const std::string& local_image)
-      : PutObjectByFileReq(bucket_name, object_name, local_image) {
-        // 图片上传时处理可能会覆盖原图，本地文件etag与上传到COS的etag文件的etag可能不一致
-        // 这种情况是合理的，所以这里不需要检查etag
-        TurnOffComputeConentMd5();
-        TurnOffCheckETag();
-      }
+      : PutObjectByFileReq(bucket_name, object_name, local_image) {}
 
   virtual ~PutImageByFileReq() {}
+
+  PicOperation GetPictureOperation() const { return m_pic_operation; }
 
   void SetPicOperation(const PicOperation& pic_operation) {
     m_pic_operation = pic_operation;
     AddHeader("Pic-Operations", m_pic_operation.GenerateJsonString());
   }
+
+  // 检查图片处理的效果图文件是否覆盖了原图
+  void CheckCoverOriginImage();  
 
  private:
   PicOperation m_pic_operation;

--- a/include/request/data_process_req.h
+++ b/include/request/data_process_req.h
@@ -601,7 +601,12 @@ class PutImageByFileReq : public PutObjectByFileReq {
   PutImageByFileReq(const std::string& bucket_name,
                     const std::string& object_name,
                     const std::string& local_image)
-      : PutObjectByFileReq(bucket_name, object_name, local_image) {}
+      : PutObjectByFileReq(bucket_name, object_name, local_image) {
+        // 图片上传时处理可能会覆盖原图，本地文件etag与上传到COS的etag文件的etag可能不一致
+        // 这种情况是合理的，所以这里不需要检查etag
+        TurnOffComputeConentMd5();
+        TurnOffCheckETag();
+      }
 
   virtual ~PutImageByFileReq() {}
 

--- a/src/cos_api.cpp
+++ b/src/cos_api.cpp
@@ -582,8 +582,9 @@ CosResult CosAPI::MoveObject(const MoveObjectReq& req) {
   return m_object_op.MoveObject(req);
 }
 
-CosResult CosAPI::PutImage(const PutImageByFileReq& req,
+CosResult CosAPI::PutImage(PutImageByFileReq& req,
                            PutImageByFileResp* resp) {
+  req.CheckCoverOriginImage();
   return m_object_op.PutImage(req, resp);
 }
 


### PR DESCRIPTION
图片上传时处理fileld参数如果与原图key一致，则会覆盖上传的原图，则本地图片Etag与COS中图片Etag不一致，这种情况不应该检查Etag